### PR TITLE
Update getting started info to indicate ipykernel version to use due to nglview problem

### DIFF
--- a/uci-pharmsci/getting-started.md
+++ b/uci-pharmsci/getting-started.md
@@ -86,6 +86,8 @@ conda install -c omnia openmm openforcefield parmed yank openmoltools pdbfixer s
 conda install -c OpenEye/label/Orion -c omnia oeommtools
 # Install plotting stuff and other prerequisites such as numerical libraries
 conda install -c conda-forge nb_conda mpld3 scikit-learn seaborn numpy matplotlib bokeh
+# Temporary fix due to https://github.com/arose/nglview/issues/726#issuecomment-356941250 -- use an older ipykernel for nglview
+conda install ipykernel=4.6.1
 # Interactive visualization in jupyter notebooks
 conda install -c bioconda nglview
 ```


### PR DESCRIPTION
Updates information on which ipykernel to (temporarily) use to bypass an issue with `nglview` as per https://github.com/arose/nglview/issues/726.