### PR TITLE
Fix broken links

### DIFF
--- a/uci-pharmsci/assigned_materials.md
+++ b/uci-pharmsci/assigned_materials.md
@@ -21,11 +21,11 @@ To prepare for Lecture 1, on Python, Linux, text editors, and GitHub, please:
 - Ideally create a (free) GitHub account in case there are issues with the course materials that you want to bring up on the GitHub repository, which houses most of our course materials.
 
 ### Before Lecture 2 ([Energy landscapes and energy minimization](lectures/energy_minimization))
-- Read the energy minimization Jupyter notebook/slides in [`uci-pharmsci/lectures/energy_minimization/energy_minimization.ipynb`](uci-pharmsci/lectures/energy_minimization/energy_minimization.ipynb)
+- Read the energy minimization Jupyter notebook/slides in [`lectures/energy_minimization/energy_minimization.ipynb`](lectures/energy_minimization/energy_minimization.ipynb)
 
 ### Before Lecture 3 ([3D structure and shape](lectures/3D_structure_shape))
 - If you don't already have a chemistry drawing tool like ChemDraw that you like, you may wish to download and install [MarvinSketch](https://www.chemaxon.com/products/marvin) for free from ChemAxon. (Though in a pinch, you can use the web demo version linked from the lecture slides if you need.)
-- Read the 3D structure/shape Jupyter notebook [`uci-pharmsci/lectures/3D_structure_shape/3D_Structure_Shape.ipynb`](uci-pharmsci/lectures/3D_structure_shape/3D_Structure_Shape.ipynb)
+- Read the 3D structure/shape Jupyter notebook [`lectures/3D_structure_shape/3D_Structure_Shape.ipynb`](lectures/3D_structure_shape/3D_Structure_Shape.ipynb)
 
 ## Before Lecture 4 ([QM](lectures/QM))
 - Skim through the PDF of the slides, noting any questions (though these provide theoretical background for subsequent classes so they are unfortunately not interactive)


### PR DESCRIPTION
Previously, links to notebooks had included the current directory in the relative path and therefore fail to resolve.